### PR TITLE
feat: avoid writing keys for non null event

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -701,10 +701,12 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
       configDef.define(
           STORE_KAFKA_KEYS_CONFIG,
-          Type.BOOLEAN,
-          false,
+          Type.STRING,
+          StoreKafkaKeys.FALSE.toString(),
+          StoreKafkaKeys.VALIDATOR,
           Importance.LOW,
-          "Enable or disable writing keys to storage. "
+          "Enable or disable writing keys to storage." +
+                "Can also write only tombstone keys, skipping event keys."
               + "This config is mandatory when the writing of tombstone records is enabled.",
           group,
           ++orderInGroup,
@@ -983,8 +985,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
            : CompressionCodecName.fromConf(getString(PARQUET_CODEC_CONFIG));
   }
 
-  public boolean storeKafkaKeys() {
-    return getBoolean(STORE_KAFKA_KEYS_CONFIG);
+  public String storeKafkaKeys() {
+    return getString(STORE_KAFKA_KEYS_CONFIG);
   }
 
   public boolean storeKafkaHeaders() {
@@ -1394,6 +1396,30 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
     public static String[] names() {
       OutputWriteBehavior[] behaviors = values();
+      String[] result = new String[behaviors.length];
+
+      for (int i = 0; i < behaviors.length; i++) {
+        result[i] = behaviors[i].toString();
+      }
+
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return name().toLowerCase(Locale.ROOT);
+    }
+  }
+
+  public enum StoreKafkaKeys {
+    FALSE,
+    TOMBSTONE_ONLY,
+    TRUE;
+
+    public static final ConfigDef.Validator VALIDATOR = new EnumValidator(names());
+
+    public static String[] names() {
+      StoreKafkaKeys[] behaviors = values();
       String[] result = new String[behaviors.length];
 
       for (int i = 0; i < behaviors.length; i++) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorValidator.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorValidator.java
@@ -88,11 +88,13 @@ public class S3SinkConnectorValidator {
     if (s3SinkConnectorConfig != null) {
       validateCompression(
           s3SinkConnectorConfig.getCompressionType(), s3SinkConnectorConfig.formatClass(),
-          s3SinkConnectorConfig.storeKafkaKeys(), s3SinkConnectorConfig.keysFormatClass(),
+          S3SinkConnectorConfig.StoreKafkaKeys.TRUE.toString().equalsIgnoreCase(s3SinkConnectorConfig.storeKafkaKeys()) ||
+              S3SinkConnectorConfig.StoreKafkaKeys.TOMBSTONE_ONLY.toString().equalsIgnoreCase(s3SinkConnectorConfig.storeKafkaKeys()), s3SinkConnectorConfig.keysFormatClass(),
           s3SinkConnectorConfig.storeKafkaHeaders(), s3SinkConnectorConfig.headersFormatClass()
       );
       validateTombstoneWriter(s3SinkConnectorConfig.isTombstoneWriteEnabled(),
-          s3SinkConnectorConfig.storeKafkaKeys());
+          S3SinkConnectorConfig.StoreKafkaKeys.TRUE.toString().equalsIgnoreCase(s3SinkConnectorConfig.storeKafkaKeys()) ||
+              S3SinkConnectorConfig.StoreKafkaKeys.TOMBSTONE_ONLY.toString().equalsIgnoreCase(s3SinkConnectorConfig.storeKafkaKeys()));
     }
 
     return new Config(new ArrayList<>(this.valuesByKey.values()));

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -203,7 +203,8 @@ public class S3SinkTask extends SinkTask {
         newFormat(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG).getRecordWriterProvider();
 
     RecordWriterProvider<S3SinkConnectorConfig> keyWriterProvider = null;
-    if (config.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG)) {
+    if (config.getString(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG).equalsIgnoreCase(S3SinkConnectorConfig.StoreKafkaKeys.TRUE.toString()) ||
+        config.getString(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG).equalsIgnoreCase(S3SinkConnectorConfig.StoreKafkaKeys.TOMBSTONE_ONLY.toString())) {
       keyWriterProvider = newFormat(S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG)
           .getRecordWriterProvider();
       ((RecordViewSetter) keyWriterProvider).setRecordView(new KeyRecordView());

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/file/AbstractFileEventConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/file/AbstractFileEventConfig.java
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
 import java.io.IOException;
 import java.util.Properties;
 
@@ -30,12 +32,12 @@ public abstract class AbstractFileEventConfig {
       if (jsonContent == null) {
         return clazz.newInstance();
       }
-      ObjectMapper instanceMapper = new ObjectMapper();
-      instanceMapper.setPropertyNamingStrategy(
-          PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
-      instanceMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-      instanceMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
-      instanceMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+      ObjectMapper instanceMapper = JsonMapper.builder()
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
+          .build();
       T value = instanceMapper.readValue(jsonContent, clazz);
       value.validateFields();
       return  value;

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -505,14 +505,14 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
   @Test
   public void testKeyStorageDefaultFalse() {
     connectorConfig = new S3SinkConnectorConfig(properties);
-    assertFalse(connectorConfig.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG));
+    assertTrue(connectorConfig.getString(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG).equalsIgnoreCase("false"));
   }
 
   @Test
   public void testKeyStorageSupported() {
     properties.put(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG, "true");
     connectorConfig = new S3SinkConnectorConfig(properties);
-    assertTrue(connectorConfig.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG));
+    assertTrue(connectorConfig.getString(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG).equalsIgnoreCase("true"));
   }
 
   @Test

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -195,11 +195,12 @@ public abstract class BaseConnectorIT {
    * <p>
    * Format: topics/s3_topic/partition=97/s3_topic+97+0000000001.avro
    *
-   * @param topic      the test kafka topic
-   * @param partition  the expected partition for the tests
-   * @param flushSize  the flush size connector config
-   * @param numRecords the number of records produced in the test
-   * @param extension  the expected extensions of the files including compression (snappy.parquet)
+   * @param topic       the test kafka topic
+   * @param partition   the expected partition for the tests
+   * @param flushSize   the flush size connector config
+   * @param numRecords  the number of records produced in the test
+   * @param extension   the expected extensions of the files including compression (snappy.parquet)
+   * @param startOffset the offset of the first record
    * @return the list of expected filenames
    */
   protected List<String> getExpectedFilenames(
@@ -207,11 +208,12 @@ public abstract class BaseConnectorIT {
       int partition,
       int flushSize,
       long numRecords,
-      String extension
+      String extension,
+      int startOffset
   ) {
     int expectedFileCount = (int) numRecords / flushSize;
     List<String> expectedFiles = new ArrayList<>();
-    for (int offset = 0; offset < expectedFileCount * flushSize; offset += flushSize) {
+    for (int offset = startOffset; offset < startOffset + expectedFileCount * flushSize; offset += flushSize) {
       String filepath = String.format(
           "topics/%s/partition=%d/%s+%d+%010d.%s",
           topic,

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkDataFormatIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkDataFormatIT.java
@@ -189,7 +189,8 @@ public class S3SinkDataFormatIT extends BaseConnectorIT {
           TOPIC_PARTITION,
           FLUSH_SIZE_STANDARD,
           NUM_RECORDS_INSERT,
-          AVRO_EXTENSION
+          AVRO_EXTENSION,
+          0
       );
       assertEquals(theseFiles.size(), countPerTopic);
       expectedTopicFilenames.addAll(theseFiles);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkFileEventIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkFileEventIT.java
@@ -223,7 +223,8 @@ public class S3SinkFileEventIT extends BaseConnectorIT {
               TOPIC_PARTITION,
               FLUSH_SIZE_STANDARD,
               NUM_RECORDS_INSERT,
-              expectedFileExtension);
+              expectedFileExtension,
+              0);
       assertEquals(theseFiles.size(), countPerTopic);
       expectedTopicFilenames.addAll(theseFiles);
     }


### PR DESCRIPTION
## Problem

We want to disable the writing of keys when the evenr is not a tombstone.

## Solution

Update the store.kafka.keys configuration to make able to take 3 values :
- true
- tombstone_only
- false

The behavior of true and false stays the same as before when the config was a boolean.
When set to tombstone_only, the key files will be written for tombstone only. Key files for event will be skipped.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
