### PR TITLE
feat: Skip null key instead of failing

### DIFF
--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -1182,20 +1182,6 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   }
 
   @Test
-  public void testExceptionOnNullKeysReported() throws Exception {
-    String recordValue = "1";
-    int kafkaOffset = 2;
-    SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null,
-        Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
-
-    String exceptionMessage = String.format("Key cannot be null for SinkRecord: %s", sinkRecordToLoggableString(faultyRecord));
-    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false, false);
-    tearDown(); // clear mock S3 port for follow up test
-    // test with faulty being first in batch
-    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, true, false);
-  }
-
-  @Test
   public void testExceptionOnEmptyHeadersReported() throws Exception{
     String recordValue = "1";
     int kafkaOffset = 2;


### PR DESCRIPTION
## Problem

We want to write the tombstone keys, but when key writing is enable, the connector fails when it encounter a null key. 

## Solution

This PR change this behavior by simply disable the key writing if the key is null. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
