### PR TITLE
fix: revert some suspicious dependency bumps

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -33,7 +33,7 @@
     </description>
 
     <properties>
-        <aws.version>1.12.524</aws.version>
+        <aws.version>1.12.268</aws.version>
         <s3mock.version>0.2.5</s3mock.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <parquet.tools.version>1.11.1</parquet.tools.version>
@@ -44,7 +44,7 @@
         <maven.avro.plugin.version>1.9.2</maven.avro.plugin.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <surefire-junit47.version>2.22.1</surefire-junit47.version>
-        <guava.version>32.1.2-jre</guava.version>
+        <guava.version>30.1.1-jre</guava.version>
         <wiremock.version>2.31.0</wiremock.version>
     </properties>
 
@@ -65,7 +65,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>${json.smart.version}</version>
+                <version>${json-smart.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -74,6 +74,21 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
+            <exclusions>
+            <exclusion>
+                <!-- This is not used by the connector and is removed to address CVE-2020-28491
+                    Once the jackson version gets upgraded consider lifting this exclusion -->
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+            </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Pinning the version of this dependency to address CVE in alignment with
+            https://github.com/confluentinc/common/pull/342
+            Once the jackson version gets upgraded consider lifting this explicit listing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -83,12 +98,6 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
-        </dependency>
-        <!--Pin snappy-java version to fix CVE-2023-34455 -->
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>${snappy.java.version}</version>
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.1</version>
+        <version>11.2.0</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -65,11 +65,14 @@
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>
-        <hadoop.version>3.3.6</hadoop.version>
+        <hadoop.version>3.2.4</hadoop.version>
         <jettison.version>1.5.4</jettison.version>
+        <json-smart.version>2.4.10</json-smart.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox.version>5.4.0</woodstox.version>
-        <snappy.java.version>1.1.10.3</snappy.java.version>
+        <jackson.core.version>2.15.0</jackson.core.version>
+        <snappy.java>1.1.10.1</snappy.java>
     </properties>
 
     <repositories>
@@ -87,17 +90,6 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
-            </dependency>
-            <!-- band aid until the connector catches up with updated pom parent -->
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${snappy.java.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bitbucket.b_c</groupId>
-                <artifactId>jose4j</artifactId>
-                <version>0.9.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -148,11 +140,11 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-partitioner</artifactId>
         </dependency>
-        <!-- <dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
             <version>${kafka.connect.storage.common.version}</version>
-        </dependency> -->
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -260,14 +252,6 @@
                 <exclusion>
                     <groupId>commons-net</groupId>
                     <artifactId>commons-net</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop.thirdparty </groupId>
-                    <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop.thirdparty </groupId>
-                    <artifactId>hadoop-shaded-guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## Problem

Looks like this bump is making the connector fails so revert them. It a revert of 4440802602871ed1dcfc52b31bd1341ce252a8d3

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
