### PR TITLE
fix regression that sets clustername to null

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/file/KafkaFileEventProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/file/KafkaFileEventProvider.java
@@ -47,6 +47,7 @@ public class KafkaFileEventProvider extends FileEventProvider {
       String fullyQualifiedRecordName) {
     String key = topicName;
     FileEvent value = FileEvent.newBuilder()
+        .setClusterName(kafkaConfig.getClusterName())
         .setTopicName(topicName)
         .setS3Partition(s3Partition)
         .setFilePath(filePath)


### PR DESCRIPTION
## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
