### PR TITLE
feat: limit concurrent buffer number to avoid OOMs

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -206,6 +206,14 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       + "being revoked from the group. It also mitigates (but does not eliminate) the risk of "
       + "a zombie task to continue writing to S3 after it has been revoked.";
 
+  public static final String MAX_CONCURRENT_PARTITION_WRITER_CONFIG =
+      "max.concurrent.partition.writer";
+  public static final int MAX_CONCURRENT_PARTITION_WRITER_DEFAULT = Integer.MAX_VALUE;
+  public static final String MAX_CONCURRENT_PARTITION_WRITER_DOC =
+      "The maximum number of S3 partition writers that may be open for a single Kafka partition at "
+          + "a time. When the limit is reached, the task pauses consumption and flushes existing "
+          + "writers before continuing.";
+
   /**
    * Maximum back-off time when retrying failed requests.
    */
@@ -761,6 +769,19 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.SHORT,
           "Maximum write duration"
+      );
+
+      configDef.define(
+          MAX_CONCURRENT_PARTITION_WRITER_CONFIG,
+          Type.INT,
+          MAX_CONCURRENT_PARTITION_WRITER_DEFAULT,
+          atLeast(0),
+          Importance.MEDIUM,
+          MAX_CONCURRENT_PARTITION_WRITER_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          "Max Concurrent Partition Writers"
       );
 
       // This is done to avoid aggressive schema based rotations resulting out of interleaving

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -85,6 +85,7 @@ public class TopicPartitionWriter {
   private final boolean ignoreTaggingErrors;
   private int recordCount;
   private final int flushSize;
+  private final int maxConcurrentPartitionWriters;
   private final long rotateIntervalMs;
   private final long rotateScheduleIntervalMs;
   private long nextScheduledRotation;
@@ -161,6 +162,9 @@ public class TopicPartitionWriter {
             S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG)
         .equalsIgnoreCase(S3SinkConnectorConfig.IgnoreOrFailBehavior.IGNORE.toString());
     flushSize = connectorConfig.getInt(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG);
+    maxConcurrentPartitionWriters = connectorConfig.getInt(
+        S3SinkConnectorConfig.MAX_CONCURRENT_PARTITION_WRITER_CONFIG
+    );
     topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
     rotateIntervalMs = connectorConfig.getLong(S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG);
     if (rotateIntervalMs > 0 && timestampExtractor == null) {
@@ -404,6 +408,9 @@ public class TopicPartitionWriter {
     }
 
     SinkRecord projectedRecord = compatibility.project(record, null, currentValueSchema);
+    if (!writers.containsKey(encodedPartition)) {
+      ensureWriterCapacity(encodedPartition);
+    }
     boolean validRecord = writeRecord(projectedRecord, encodedPartition, record);
     buffer.poll();
     if (!validRecord) {
@@ -602,6 +609,26 @@ public class TopicPartitionWriter {
     log.trace("Resuming writer for topic-partition '{}'", tp);
     context.resume(tp);
     isPaused = false;
+  }
+
+  private void ensureWriterCapacity(String encodedPartition) {
+    if (maxConcurrentPartitionWriters <= 0) {
+      return;
+    }
+    if (writers.size() < maxConcurrentPartitionWriters) {
+      return;
+    }
+    log.info(
+        "Maximum number of concurrent partition writers ({}) reached for {}. "
+            + "Pausing consumption and flushing existing writers before continuing with '{}'.",
+        maxConcurrentPartitionWriters,
+        tp,
+        encodedPartition
+    );
+    pause();
+    if (!commitFiles.isEmpty()) {
+      commitFiles();
+    }
   }
 
   private RecordWriter newWriter(SinkRecord record, String encodedPartition)

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -158,11 +158,11 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
   public void testFilenameFormatValidatorAcceptsAllowedPlaceholders() {
     properties.put(
         S3_OBJECT_FILENAME_FORMAT_CONFIG,
-        "custom${fileDelim}${topic}${fileDelim}${randomId}"
+        "custom${fileDelim}${topic}${fileDelim}${randomUuid}"
     );
     connectorConfig = new S3SinkConnectorConfig(properties);
     assertEquals(
-        "custom${fileDelim}${topic}${fileDelim}${randomId}",
+        "custom${fileDelim}${topic}${fileDelim}${randomUuid}",
         connectorConfig.getString(S3_OBJECT_FILENAME_FORMAT_CONFIG)
     );
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -77,6 +77,7 @@ import io.confluent.connect.s3.util.FileUtils;
 import io.confluent.connect.s3.util.TimeUtils;
 import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.format.Format;
+import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
 import io.confluent.connect.storage.partitioner.DailyPartitioner;
 import io.confluent.connect.storage.partitioner.DefaultPartitioner;
@@ -1862,6 +1863,122 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     );
   }
 
+  @Test
+  public void testMaxConcurrentPartitionWriterFlushesWhenLimitReached() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(S3SinkConnectorConfig.MAX_CONCURRENT_PARTITION_WRITER_CONFIG, "1");
+    setUp();
+
+    Partitioner<?> partitioner = new FieldPartitioner<>();
+    String field = "field";
+    parsedConfig.put(PARTITION_FIELD_NAME_CONFIG, Collections.singletonList(field));
+    partitioner.configure(parsedConfig);
+
+    SinkTaskContext mockContext = mock(SinkTaskContext.class);
+    TrackingRecordWriterProvider trackingWriterProvider = new TrackingRecordWriterProvider();
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, trackingWriterProvider, partitioner, connectorConfig, mockContext, null
+    );
+
+    Schema schema = SchemaBuilder.struct().field(field, Schema.STRING_SCHEMA).build();
+    Struct recordA = new Struct(schema).put(field, "a");
+    Struct recordB = new Struct(schema).put(field, "b");
+    topicPartitionWriter.buffer(
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "keyA", schema, recordA, 0)
+    );
+    topicPartitionWriter.buffer(
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "keyB", schema, recordB, 1)
+    );
+
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    assertEquals(
+        "Existing writers should be flushed before opening a new partition writer",
+        1,
+        trackingWriterProvider.commitCount()
+    );
+    Mockito.verify(mockContext, Mockito.atLeast(2)).pause(TOPIC_PARTITION);
+    Mockito.verify(mockContext, Mockito.atLeastOnce()).resume(TOPIC_PARTITION);
+  }
+
+  @Test
+  public void testMaxConcurrentPartitionWriterDoesNotFlushWhenWithinLimit() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(S3SinkConnectorConfig.MAX_CONCURRENT_PARTITION_WRITER_CONFIG, "2");
+    setUp();
+
+    Partitioner<?> partitioner = new FieldPartitioner<>();
+    String field = "field";
+    parsedConfig.put(PARTITION_FIELD_NAME_CONFIG, Collections.singletonList(field));
+    partitioner.configure(parsedConfig);
+
+    TrackingRecordWriterProvider trackingWriterProvider = new TrackingRecordWriterProvider();
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, trackingWriterProvider, partitioner, connectorConfig, context, null
+    );
+
+    Schema schema = SchemaBuilder.struct().field(field, Schema.STRING_SCHEMA).build();
+    Struct recordA = new Struct(schema).put(field, "a");
+    Struct recordB = new Struct(schema).put(field, "b");
+    topicPartitionWriter.buffer(
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "keyA", schema, recordA, 0)
+    );
+    topicPartitionWriter.buffer(
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "keyB", schema, recordB, 1)
+    );
+
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    assertEquals(
+        "Writers should not be flushed early when the limit is not exceeded",
+        0,
+        trackingWriterProvider.commitCount()
+    );
+  }
+
+  @Test
+  public void testMaxConcurrentPartitionWriterUnlimitedDoesNotFlush() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(S3SinkConnectorConfig.MAX_CONCURRENT_PARTITION_WRITER_CONFIG, "0");
+    setUp();
+
+    Partitioner<?> partitioner = new FieldPartitioner<>();
+    String field = "field";
+    parsedConfig.put(PARTITION_FIELD_NAME_CONFIG, Collections.singletonList(field));
+    partitioner.configure(parsedConfig);
+
+    SinkTaskContext mockContext = mock(SinkTaskContext.class);
+    TrackingRecordWriterProvider trackingWriterProvider = new TrackingRecordWriterProvider();
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, trackingWriterProvider, partitioner, connectorConfig, mockContext, null
+    );
+
+    Schema schema = SchemaBuilder.struct().field(field, Schema.STRING_SCHEMA).build();
+    Struct recordA = new Struct(schema).put(field, "a");
+    Struct recordB = new Struct(schema).put(field, "b");
+    Struct recordC = new Struct(schema).put(field, "c");
+    topicPartitionWriter.buffer(
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "keyA", schema, recordA, 0)
+    );
+    topicPartitionWriter.buffer(
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "keyB", schema, recordB, 1)
+    );
+    topicPartitionWriter.buffer(
+        new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "keyC", schema, recordC, 2)
+    );
+
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    assertEquals(
+        "Unlimited concurrent partition writers should not trigger flushes",
+        0,
+        trackingWriterProvider.commitCount()
+    );
+  }
+
   private List<Object> generateTestDataWithSchema(
       Partitioner<?> partitioner, S3SinkConnectorConfig.AffixType affixType
   ) {
@@ -2396,6 +2513,48 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Invoke write so as to simulate tagging error.
     topicPartitionWriter.write();
     topicPartitionWriter.close();
+  }
+
+  private static class TrackingRecordWriterProvider
+      implements RecordWriterProvider<S3SinkConnectorConfig> {
+    private final AtomicInteger commitCount = new AtomicInteger();
+
+    @Override
+    public RecordWriter getRecordWriter(S3SinkConnectorConfig config, String filename) {
+      return new TrackingRecordWriter(commitCount);
+    }
+
+    @Override
+    public String getExtension() {
+      return ".tracking";
+    }
+
+    int commitCount() {
+      return commitCount.get();
+    }
+  }
+
+  private static class TrackingRecordWriter implements RecordWriter {
+    private final AtomicInteger commitCount;
+
+    TrackingRecordWriter(AtomicInteger commitCount) {
+      this.commitCount = commitCount;
+    }
+
+    @Override
+    public void write(SinkRecord record) {
+      // no-op
+    }
+
+    @Override
+    public void commit() {
+      commitCount.incrementAndGet();
+    }
+
+    @Override
+    public void close() {
+      // no-op
+    }
   }
 
   public static class MockedWallclockTimestampExtractor implements TimestampExtractor {


### PR DESCRIPTION
## Problem

When we add an already existing topic with lot of history and partitions, the connector fails with OOMs because it tries to open a lot of buffers concurrently. 

## Solution

This PR introduce a new configuration allowing to limit the number of concurrent buffer and avoid the OOMs

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
